### PR TITLE
prevent app from crashing when invoking plugin callback

### DIFF
--- a/calatrava-ios/Bridge/PluginRegistry.m
+++ b/calatrava-ios/Bridge/PluginRegistry.m
@@ -39,6 +39,7 @@
 {
   [runtime callJsFunction:@"calatrava.inbound.invokePluginCallback"
                  withArgs:@[handle, data]];
+  return self;
 }
 
 @end


### PR DESCRIPTION
Currently the app crashes when invoking plugin callback
