### PR TITLE
change return type of attachToRuntime to void

### DIFF
--- a/calatrava-ios/Bridge/PluginRegistry.h
+++ b/calatrava-ios/Bridge/PluginRegistry.h
@@ -9,7 +9,7 @@
   NSMutableDictionary *registeredPlugins;
 }
 
-- (id)attachToRuntime:(id<JsRuntime>)rt;
+- (void)attachToRuntime:(id<JsRuntime>)rt;
 
 - (id) registerPlugin:(NSObject<RegisteredPlugin> *)plugin
                 named:(NSString *)name;

--- a/calatrava-ios/Bridge/PluginRegistry.m
+++ b/calatrava-ios/Bridge/PluginRegistry.m
@@ -12,7 +12,7 @@
   return self;
 }
 
-- (id)attachToRuntime:(id<JsRuntime>)rt
+- (void)attachToRuntime:(id<JsRuntime>)rt
 {
   runtime = rt;
   [rt setPluginDelegate:self];


### PR DESCRIPTION
That fixes the XCode 4.6 crash when running in debug configuration
