### PR TITLE
Use WebViewController if no custom UIViewController is found

### DIFF
--- a/calatrava-ios/Bridge/TWBridgePageRegistry.m
+++ b/calatrava-ios/Bridge/TWBridgePageRegistry.m
@@ -1,4 +1,5 @@
 #import "TWBridgePageRegistry.h"
+#import "WebViewController.h"
 
 static TWBridgePageRegistry *bridge_instance = nil;
 
@@ -157,14 +158,21 @@ static TWBridgePageRegistry *bridge_instance = nil;
   if (!page)
   {
     NSString *viewControllerName = [pageName stringByAppendingString:@"ViewController"];
-    id factory = NSClassFromString(viewControllerName);
     NSLog(@"VC: %@", viewControllerName);
-    page = [[factory alloc] initWithNibName:nil bundle:nil];
+    Class factory = NSClassFromString(viewControllerName);
+    
+    if (factory) {
+      page = [[factory alloc] initWithNibName:nil bundle:nil];
+    } else {
+      page = [[WebViewController alloc] initWithPageName:pageName];
+    }
+
     [pageObjects setObject:page forKey:pageName];
   }
   
   return page;
 }
+
 
 - (NSString *)convertPageNameToClassName:(NSString *)pageName {
   return [pageName stringByReplacingCharactersInRange:NSMakeRange(0,1) withString:[[pageName substringToIndex:1] uppercaseString]];

--- a/calatrava-ios/Bridge/TWBridgePageRegistry.m
+++ b/calatrava-ios/Bridge/TWBridgePageRegistry.m
@@ -61,7 +61,7 @@ static TWBridgePageRegistry *bridge_instance = nil;
 
 - (id)registerProxy:(NSString *)proxyId forPage:(NSString *)name
 {
-  [pageProxyIds setObject:[self convertPageNameToClassName:name] forKey:proxyId];
+  [pageProxyIds setObject:name forKey:proxyId];
   return self;
 }
 
@@ -149,15 +149,12 @@ static TWBridgePageRegistry *bridge_instance = nil;
 - (id)ensurePageWithName:(NSString *)pageName
 {
   NSLog(@"pageName: %@", pageName);
-  pageName = [self convertPageNameToClassName:pageName];
-  NSLog(@"capitalized pageName: %@", pageName);
-  
   id page = [pageObjects objectForKey:pageName];
   NSLog(@"page: %@", page);
   
   if (!page)
   {
-    NSString *viewControllerName = [pageName stringByAppendingString:@"ViewController"];
+    NSString *viewControllerName = [[self convertPageNameToClassName:pageName] stringByAppendingString:@"ViewController"];
     NSLog(@"VC: %@", viewControllerName);
     Class factory = NSClassFromString(viewControllerName);
     

--- a/calatrava-ios/Shell/WebViewController.h
+++ b/calatrava-ios/Shell/WebViewController.h
@@ -9,6 +9,7 @@
   BOOL webViewReady;
 }
 
+- (id)initWithPageName:(NSString *)thePageName;
 - (NSString *)pageName;
 
 @end

--- a/calatrava-ios/Shell/WebViewController.m
+++ b/calatrava-ios/Shell/WebViewController.m
@@ -7,32 +7,46 @@
 - (void)removeWebViewBounceShadow;
 @end
 
-@implementation WebViewController
-
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
-    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self) {
-      queuedBinds = [[NSMutableOrderedSet alloc] init];
-      queuedRenders = [[NSMutableOrderedSet alloc] init];
-      
-      webViewReady = NO;
-      
-      _webView = [[UIWebView alloc] init];
-      [self setView:_webView];
-      [_webView setDelegate:self];
-      [self removeWebViewBounceShadow];
-      
-      NSString *bundle = [[NSBundle mainBundle] bundlePath];
-      [_webView loadRequest:[NSURLRequest requestWithURL:
-                             [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/public/views/%@.html", bundle, [self pageName]]]]];
-    }
-    return self;
+@implementation WebViewController {
+  NSString *pageName;
 }
 
-- (NSString *)pageName
-{
-  // No-op implementation. Override in sub class
-  return @"OVERRIDE pageName IN SUB-CLASS";
+- (id)initWithPageName:(NSString *)thePageName {
+  if (self = [super initWithNibName:nil bundle:nil]) {
+    pageName = thePageName;
+    [self initWebView];
+  }
+
+  return self;
+}
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
+    pageName = @"OVERRIDE pageName IN SUB-CLASS"; // default page name
+    [self initWebView];
+  }
+  
+  return self;
+}
+
+- (void)initWebView {
+  queuedBinds = [[NSMutableOrderedSet alloc] init];
+  queuedRenders = [[NSMutableOrderedSet alloc] init];
+  
+  webViewReady = NO;
+  
+  _webView = [[UIWebView alloc] init];
+  [self setView:_webView];
+  [_webView setDelegate:self];
+  [self removeWebViewBounceShadow];
+  
+  NSString *bundle = [[NSBundle mainBundle] bundlePath];
+  [_webView loadRequest:[NSURLRequest requestWithURL:
+                         [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/public/views/%@.html", bundle, [self pageName]]]]];
+}
+
+- (NSString *)pageName {
+  return pageName;
 }
 
 #pragma mark - View lifecycle


### PR DESCRIPTION
Hey,

As I've been getting my head around Calatrava, I found it quite counter-intuitive that the iOS apps weren't showing the shell views if I didn't provide a native implementation. At a bare minimum, it required that I create a subclass of `WebViewController` and set the `pageName` to the same as my shell view. This seemed to go against the idea that at a minimum you could just build a shell, and replace the views piecemeal.

I had a look and realised it wouldn't be much work to change Calatrava's page retrieval/creation logic to default to using a `WebViewController` instance (with the `pageName` set) if no custom ViewController could be found.

What do you think?

Context: https://groups.google.com/d/topic/calatrava-mobile/dZnDmBJ7WGY/discussion

Cheers,
James
