### PR TITLE
[ios] Safer javascript execution

### DIFF
--- a/calatrava-ios.xcodeproj/project.pbxproj
+++ b/calatrava-ios.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		C6301C6C15C208CF00E9E27F /* WebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C6301C2F15C208CF00E9E27F /* WebViewController.m */; };
 		C6C851A815D88AB900445924 /* WebRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = C6C851A615D88AB900445924 /* WebRuntime.h */; };
 		C6C851A915D88AB900445924 /* WebRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = C6C851A715D88AB900445924 /* WebRuntime.m */; };
+		D78C6EBD9DBA265CC333DA7F /* UIWebView+SafeJavaScriptExecution.m in Sources */ = {isa = PBXBuildFile; fileRef = D78C6D10484A4A517F7CD0B3 /* UIWebView+SafeJavaScriptExecution.m */; };
+		D78C6EE438A7C26866711581 /* UIWebView+SafeJavaScriptExecution.h in Headers */ = {isa = PBXBuildFile; fileRef = D78C67DFA18B6A14C102B41E /* UIWebView+SafeJavaScriptExecution.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,6 +57,8 @@
 		C632C7E515D6E3CA00203D4B /* JsRuntime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JsRuntime.h; sourceTree = "<group>"; };
 		C6C851A615D88AB900445924 /* WebRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebRuntime.h; sourceTree = "<group>"; };
 		C6C851A715D88AB900445924 /* WebRuntime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebRuntime.m; sourceTree = "<group>"; };
+		D78C67DFA18B6A14C102B41E /* UIWebView+SafeJavaScriptExecution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWebView+SafeJavaScriptExecution.h"; sourceTree = "<group>"; };
+		D78C6D10484A4A517F7CD0B3 /* UIWebView+SafeJavaScriptExecution.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWebView+SafeJavaScriptExecution.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +115,8 @@
 			isa = PBXGroup;
 			children = (
 				C6301B5515C2036000E9E27F /* calatrava-ios-Prefix.pch */,
+				D78C6D10484A4A517F7CD0B3 /* UIWebView+SafeJavaScriptExecution.m */,
+				D78C67DFA18B6A14C102B41E /* UIWebView+SafeJavaScriptExecution.h */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -180,6 +186,7 @@
 				C6C851A815D88AB900445924 /* WebRuntime.h in Headers */,
 				C6088F0D16404949002F6B00 /* PluginRegistry.h in Headers */,
 				C6088F1A1647B2D8002F6B00 /* AlertPlugin.h in Headers */,
+				D78C6EE438A7C26866711581 /* UIWebView+SafeJavaScriptExecution.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -244,6 +251,7 @@
 				C6C851A915D88AB900445924 /* WebRuntime.m in Sources */,
 				C6088F0E16404949002F6B00 /* PluginRegistry.m in Sources */,
 				C6088F1B1647B2D8002F6B00 /* AlertPlugin.m in Sources */,
+				D78C6EBD9DBA265CC333DA7F /* UIWebView+SafeJavaScriptExecution.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/calatrava-ios/Bridge/WebRuntime.m
+++ b/calatrava-ios/Bridge/WebRuntime.m
@@ -1,4 +1,5 @@
 #import "WebRuntime.h"
+#import "UIWebView+SafeJavaScriptExecution.h"
 
 @interface WebRuntime()
 
@@ -42,7 +43,7 @@
   {
     NSLog(@"Loading: %@", path);
     ++outstandingScriptLoads;
-    [rtWebView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"calatrava.bridge.native.load('%@');", path]];
+    [rtWebView stringBySafelyEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"calatrava.bridge.native.load('%@');", path]];
   }
 }
 
@@ -57,7 +58,7 @@
   else
   {
     NSString *funcCall = [NSString stringWithFormat:@"%@(%@);", function, [self argsToString:args]];
-    NSString *returnVal = [rtWebView stringByEvaluatingJavaScriptFromString:funcCall];
+    NSString *returnVal = [rtWebView stringBySafelyEvaluatingJavaScriptFromString:funcCall];
     NSLog(@"Function '%@' returned: %@", funcCall, returnVal);
   }
 }
@@ -89,7 +90,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
   {
     NSArray *functionAndArgs = [[requestString substringFromIndex:[funcPrefix length]] componentsSeparatedByString:@"&"];
     NSString *function = [functionAndArgs objectAtIndex:0];
-    NSString *argsJson = [rtWebView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"calatrava.bridge.native.getArgs('%@');", [functionAndArgs objectAtIndex:1]]];
+    NSString *argsJson = [rtWebView stringBySafelyEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"calatrava.bridge.native.getArgs('%@');", [functionAndArgs objectAtIndex:1]]];
     NSLog(@"Targeting: %@", function);
     NSLog(@"With args: %@", argsJson);
     NSArray *args = (NSArray *)[NSJSONSerialization JSONObjectWithData:[argsJson dataUsingEncoding:NSUTF8StringEncoding]

--- a/calatrava-ios/Shell/WebViewController.m
+++ b/calatrava-ios/Shell/WebViewController.m
@@ -1,4 +1,5 @@
 #import "WebViewController.h"
+#import "UIWebView+SafeJavaScriptExecution.h"
 
 @interface WebViewController()
 - (void)renderMessage:(NSDictionary *)message;
@@ -55,7 +56,7 @@
 }
 
 - (id)valueForField:(NSString *)field {
-  return [_webView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"window.%@View.get('%@');", [self pageName], field]];
+  return [_webView stringBySafelyEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"window.%@View.get('%@');", [self pageName], field]];
 }
 
 - (id)attachHandler:(NSString *)proxyId forEvent:(NSString *)event
@@ -72,7 +73,7 @@
 - (void)bindWebEvent:(NSString *)event
 {
   NSString *jsCode = [NSString stringWithFormat:@"window.%@View.bind('%@', tw.batSignalFor('%@'));", [self pageName], event, event];
-  [_webView stringByEvaluatingJavaScriptFromString:jsCode];
+  [_webView stringBySafelyEvaluatingJavaScriptFromString:jsCode];
 }
 
 - (void)renderMessage:(NSDictionary *)message
@@ -85,7 +86,7 @@
   NSLog(@"Page name: %@", [self pageName]);
   
   NSString *render = [NSString stringWithFormat:@"window.%@View.render(%@);", [self pageName], responseJson];
-  [_webView stringByEvaluatingJavaScriptFromString:render];
+  [_webView stringBySafelyEvaluatingJavaScriptFromString:render];
 }
 
 # pragma mark - WebView delegate methods

--- a/calatrava-ios/UIWebView+SafeJavaScriptExecution.h
+++ b/calatrava-ios/UIWebView+SafeJavaScriptExecution.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface UIWebView (SafeJavaScriptExecution)
+
+- (NSString *)stringBySafelyEvaluatingJavaScriptFromString:(NSString *)js;
+
+@end

--- a/calatrava-ios/UIWebView+SafeJavaScriptExecution.m
+++ b/calatrava-ios/UIWebView+SafeJavaScriptExecution.m
@@ -1,0 +1,32 @@
+#import "UIWebView+SafeJavaScriptExecution.h"
+
+@implementation UIWebView (SafeJavaScriptExecution)
+
+- (NSString *)stringBySafelyEvaluatingJavaScriptFromString:(NSString *)js {
+  NSString *result = [self stringByEvaluatingJavaScriptFromString:[self wrapScriptInTryCatch:js]];
+
+  if (!result) {
+    // according to this StackOverflow answer http://stackoverflow.com/a/7389032/27206
+    // stringByEvaluatingJavaScriptFromString may return nil to indicate an execution timeout.
+    @throw [NSException
+      exceptionWithName:@"JavaScript Unknown Exception"
+                 reason:@"stringByEvaluatingJavaScriptFromString returned nil, which usually indicates a timeout"
+               userInfo:nil];
+  }
+
+  if ([result hasPrefix:@"@@EX@@"]) {
+    // the javascript execution failed with an unhandled exception, result should contain the exception
+    @throw [NSException
+      exceptionWithName:@"JavaScript Exception"
+                 reason:[result stringByReplacingOccurrencesOfString:@"@@EX@@" withString:@""]
+               userInfo:nil];
+  }
+
+  return result;
+}
+
+- (NSString *)wrapScriptInTryCatch:(NSString *)js {
+  return [NSString stringWithFormat:@"(function() { try { return %@; } catch (ex) { return '@@EX@@' + ex.toString() + '\\n' + ex.stack.toString(); } })();", js];
+}
+
+@end


### PR DESCRIPTION
Whenever javascript is executed in the web views, namely to render pages or fire events, there's the possibility the call might throw an exception; when an exception is uncaught, the whole javascript execution fails and the app becomes useless.

This change wraps every call to the javascript runtime in a try...catch block and returns any unhandled exceptions to the caller (in string form, as you can't return objects). If the resulting string contains an exception, it's rethrown as a native NSException. This makes the app fail fast if there's a javascript error, I think that's the right thing to do.

Effectively, every native call to javascript has changed from:

``` javascript
views.something.render('abc');
```

to looking like this:

``` javascript
(function() {
  try {
    return views.something.render('abc');
  } catch (ex) {
    return '@@EX@@' + ex.toString() + '\n' + ex.stack.toString();
  }
})();
```
