### PR TITLE
Fixes a startup crash

### DIFF
--- a/calatrava-ios/Bridge/PluginRegistry.m
+++ b/calatrava-ios/Bridge/PluginRegistry.m
@@ -16,6 +16,7 @@
 {
   runtime = rt;
   [rt setPluginDelegate:self];
+  return self;
 }
 
 - (id) registerPlugin:(NSObject<RegisteredPlugin> *)plugin


### PR DESCRIPTION
Any method that has a return type needs to have an explicit return.  This didn't fail on the simulator, but it did when running on an iPhone 5.
